### PR TITLE
Fix MNIST pipeline and migrate tests to unittest

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ Install `fastmlx` using `pip`:
 ```bash
 pip install -e .
 ```
+
+## Running Tests
+
+The unit tests use Python's ``unittest`` framework. Run all tests with:
+
+```bash
+python -m unittest discover -s tests
+```

--- a/fastmlx/apphub/mnist.py
+++ b/fastmlx/apphub/mnist.py
@@ -17,10 +17,12 @@ from fastmlx.trace.adapt import LRScheduler
 
 def get_estimator(epochs: int = 2, batch_size: int = 32, save_dir: str = tempfile.mkdtemp()) -> fe.Estimator:
     train_data, eval_data = mnist.load_data()
-    pipeline = fe.Pipeline(train_data=train_data,
-                           eval_data=eval_data,
-                           batch_size=batch_size,
-                           ops=[ExpandDims(inputs="x", outputs="x"), Minmax(inputs="x", outputs="x")])
+    pipeline = fe.Pipeline(
+        train_data=train_data,
+        eval_data=eval_data,
+        batch_size=batch_size,
+        ops=[ExpandDims(inputs="x", outputs="x", axis=-1), Minmax(inputs="x", outputs="x")],
+    )
     model = fe.build(model_fn=lambda: LeNet(input_shape=(1,28,28)), optimizer_fn="adam")
     network = fe.Network([
         ModelOp(model=model, inputs="x", outputs="y_pred"),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_lenet.py
+++ b/tests/test_lenet.py
@@ -1,11 +1,23 @@
+import unittest
+
 import mlx.core as mx
+
 from fastmlx.architecture import LeNet
 
 
-def test_lenet_forward():
-    model = LeNet()
-    mx.eval(model.parameters())
-    x = mx.random.uniform(shape=(2, 28, 28, 1))
-    y = model(x)
-    assert y.shape == (2, 10)
+class TestLeNet(unittest.TestCase):
+    """Unit tests for the :class:`LeNet` architecture."""
+
+    def test_forward(self) -> None:
+        """Ensure that the network produces the expected output shape."""
+
+        model = LeNet()
+        mx.eval(model.parameters())
+        x = mx.random.uniform(shape=(2, 28, 28, 1))
+        y = model(x)
+        self.assertEqual(y.shape, (2, 10))
+
+
+if __name__ == "__main__":
+    unittest.main()
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,14 +1,29 @@
+import unittest
+
 import numpy as np
+
 import fastmlx as fe
 from fastmlx.dataset import NumpyDataset
 from fastmlx.op.numpyop import ExpandDims, Minmax
 
 
-def test_pipeline_ops():
-    data = NumpyDataset({'x': np.zeros((4, 28, 28), dtype=np.uint8)})
-    pipe = fe.Pipeline(train_data=data, batch_size=2,
-                       ops=[ExpandDims('x', 'x', axis=-1), Minmax('x', 'x')])
-    loader = pipe.get_loader('train')
-    batch = next(iter(loader))
-    assert batch['x'].shape == (2, 28, 28, 1)
-    assert np.allclose(batch['x'], 0.0)
+class TestPipeline(unittest.TestCase):
+    """Tests for the :class:`Pipeline` data processing."""
+
+    def test_pipeline_ops(self) -> None:
+        """Ensure ops run and produce expected results."""
+
+        data = NumpyDataset({"x": np.zeros((4, 28, 28), dtype=np.uint8)})
+        pipe = fe.Pipeline(
+            train_data=data,
+            batch_size=2,
+            ops=[ExpandDims("x", "x", axis=-1), Minmax("x", "x")],
+        )
+        loader = pipe.get_loader("train")
+        batch = next(iter(loader))
+        self.assertEqual(batch["x"].shape, (2, 28, 28, 1))
+        self.assertTrue(np.allclose(batch["x"], 0.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,8 +1,17 @@
+import unittest
+
 from fastmlx.schedule import cosine_decay
 
 
-def test_cosine_decay():
-    lr = cosine_decay(step=0, cycle_length=10, init_lr=1.0)
-    assert abs(lr - 1.0) < 1e-6
-    lr_mid = cosine_decay(step=5, cycle_length=10, init_lr=1.0)
-    assert lr_mid < 1.0
+class TestSchedule(unittest.TestCase):
+    """Tests for the cosine decay scheduler."""
+
+    def test_cosine_decay(self) -> None:
+        lr = cosine_decay(step=0, cycle_length=10, init_lr=1.0)
+        self.assertAlmostEqual(lr, 1.0)
+        lr_mid = cosine_decay(step=5, cycle_length=10, init_lr=1.0)
+        self.assertLess(lr_mid, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix MNIST example by adding channel axis in pipeline
- rewrite tests using Python's unittest module
- add helper for test path setup
- document how to run tests in README

## Testing
- `python -m unittest discover -s tests -v`
- `pytest -q`