### PR TITLE
Fix MNIST dataset labels and training gradient

### DIFF
--- a/fastmlx/dataset/data/mnist.py
+++ b/fastmlx/dataset/data/mnist.py
@@ -13,9 +13,9 @@ def load_data(image_key: str = "x", label_key: str = "y") -> Tuple[MLXDataset, M
     train_buffer = mlx_mnist.load_mnist(train=True)
     test_buffer = mlx_mnist.load_mnist(train=False)
     train_images = mx.stack([mx.array(d["image"]) for d in train_buffer])
-    train_labels = mx.array([d["label"] for d in train_buffer])
+    train_labels = mx.array([int(d["label"]) for d in train_buffer])
     test_images = mx.stack([mx.array(d["image"]) for d in test_buffer])
-    test_labels = mx.array([d["label"] for d in test_buffer])
+    test_labels = mx.array([int(d["label"]) for d in test_buffer])
     train = MLXDataset({image_key: train_images, label_key: train_labels})
     test = MLXDataset({image_key: test_images, label_key: test_labels})
     return train, test

--- a/fastmlx/op/tensorop/model.py
+++ b/fastmlx/op/tensorop/model.py
@@ -27,7 +27,24 @@ class UpdateOp(Op):
         self.model: nn.Module = model
 
     def forward(self, data: Array, state: MutableMapping[str, Any]) -> None:
-        loss = data
-        grads = mx.grad(loss, self.model.trainable_parameters())
+        batch = state.get("batch", {})
+        x = batch.get("x")
+        y = batch.get("y")
+        if x is None or y is None:
+            return None
+
+        if not isinstance(x, mx.array):
+            x = mx.array(x)
+        if not isinstance(y, mx.array):
+            y = mx.array(y)
+
+        def loss_fn(x_data, y_data):
+            logits = self.model(x_data)
+            loss = nn.losses.cross_entropy(logits, y_data)
+            return mx.mean(loss)
+
+        value, grads = nn.value_and_grad(self.model, loss_fn)(x, y)
+        batch[self.inputs[0]] = value
         self.model.optimizer.update(self.model, grads)
+        mx.eval(self.model.parameters())
         return None

--- a/tests/test_mnist_data.py
+++ b/tests/test_mnist_data.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch
+import numpy as np
+import mlx.core as mx
+from fastmlx.dataset.data import mnist
+
+
+class TestMNISTLoadData(unittest.TestCase):
+    def test_load_data_converts_numpy_scalars(self):
+        def fake_load_mnist(train=True):
+            # return two samples with numpy arrays and numpy scalar labels
+            return [
+                {"image": np.zeros((28, 28, 1), dtype=np.uint8), "label": np.int64(1)},
+                {"image": np.ones((28, 28, 1), dtype=np.uint8), "label": np.int64(2)},
+            ]
+
+        with patch("fastmlx.dataset.data.mnist.mlx_mnist.load_mnist", side_effect=fake_load_mnist):
+            train, test = mnist.load_data()
+            # ensure arrays are MX arrays
+            self.assertIsInstance(train.data["x"], mx.array)
+            self.assertIsInstance(train.data["y"], mx.array)
+            self.assertEqual(train.data["x"].shape, (2, 28, 28, 1))
+            self.assertTrue(mx.array_equal(train.data["y"], mx.array([1, 2])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mnist_estimator.py
+++ b/tests/test_mnist_estimator.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch
+import numpy as np
+import mlx.core as mx
+from fastmlx.apphub import mnist as mnist_app
+
+
+class TestMNISTEstimator(unittest.TestCase):
+    def test_single_training_step(self):
+        def fake_load_mnist(train=True):
+            # create four samples to form two batches
+            return [
+                {"image": np.zeros((28, 28, 1), dtype=np.uint8), "label": np.int64(1)},
+                {"image": np.ones((28, 28, 1), dtype=np.uint8), "label": np.int64(0)},
+                {"image": np.zeros((28, 28, 1), dtype=np.uint8), "label": np.int64(1)},
+                {"image": np.ones((28, 28, 1), dtype=np.uint8), "label": np.int64(0)},
+            ]
+
+        with patch("fastmlx.dataset.data.mnist.mlx_mnist.load_mnist", side_effect=fake_load_mnist):
+            est = mnist_app.get_estimator(epochs=1, batch_size=2)
+            loader = est.pipeline.get_loader("train")
+            batch = next(iter(loader))
+            state = {"mode": "train"}
+            est.network.run(batch, state)
+            # ensure a loss key is generated
+            self.assertIn("ce", batch)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure MNIST loader converts numpy scalar labels to python ints
- rewrite `UpdateOp` to compute gradients with `nn.value_and_grad`
- add tests covering MNIST dataset loading and a single training step

## Testing
- `pytest -q`