### PR TITLE
Fix CIFAR10 labels and improve training logs

### DIFF
--- a/fastmlx/dataset/data/cifar10.py
+++ b/fastmlx/dataset/data/cifar10.py
@@ -13,9 +13,12 @@ def load_data(image_key: str = "x", label_key: str = "y") -> Tuple[MLXDataset, M
     train_buffer = cifar.load_cifar10(train=True)
     test_buffer = cifar.load_cifar10(train=False)
     train_images = mx.stack([mx.array(d["image"]) for d in train_buffer])
-    train_labels = mx.array([d["label"] for d in train_buffer])
+    # Cast labels to Python ints in case the underlying dataset stores them as
+    # numpy scalar types.  This mirrors the handling in the MNIST loader and
+    # avoids ``mx.array`` complaining about unsupported ``ndarray`` inputs.
+    train_labels = mx.array([int(d["label"]) for d in train_buffer])
     test_images = mx.stack([mx.array(d["image"]) for d in test_buffer])
-    test_labels = mx.array([d["label"] for d in test_buffer])
+    test_labels = mx.array([int(d["label"]) for d in test_buffer])
     train = MLXDataset({image_key: train_images, label_key: train_labels})
     test = MLXDataset({image_key: test_images, label_key: test_labels})
     return train, test

--- a/fastmlx/estimator.py
+++ b/fastmlx/estimator.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Iterable, List, MutableMapping, Optional
 
+import mlx.core as mx
+
 from .pipeline import Pipeline
 from .network import Network
 
@@ -12,31 +14,58 @@ class Estimator:
     """Run a :class:`~fastmlx.pipeline.Pipeline` using a :class:`~fastmlx.network.Network`."""
 
     def __init__(self, pipeline: Pipeline, network: Network, epochs: int,
-                 traces: Optional[Iterable[object]] | None = None) -> None:
+                 traces: Optional[Iterable[object]] | None = None,
+                 log_interval: int = 100) -> None:
         self.pipeline: Pipeline = pipeline
         self.network: Network = network
         self.epochs: int = epochs
         self.traces: List[object] = list(traces or [])
+        self.log_interval = log_interval
 
     def fit(self) -> MutableMapping[str, object]:
-        """Train the network."""
+        """Train the network with periodic logging similar to FastEstimator."""
+
+        import time
 
         state: MutableMapping[str, object] = {}
+        step = 0
+        print(
+            f"FastMLX-Start: step: 1; logging_interval: {self.log_interval}; num_device: 1;"
+        )
         for epoch in range(self.epochs):
+            epoch_start = time.time()
             state = {"mode": "train", "epoch": epoch, "metrics": {}}
             for t in self.traces:
                 if hasattr(t, "on_epoch_begin"):
                     t.on_epoch_begin(state)
             for batch in self.pipeline.get_loader("train"):
+                step += 1
+                batch_start = time.time()
                 state["batch"] = batch
                 self.network.run(batch, state)
                 for t in self.traces:
                     if hasattr(t, "on_batch_end"):
                         t.on_batch_end(batch, state)
+                if step % self.log_interval == 0:
+                    lr = getattr(self.network.ops[0].model.optimizer, "learning_rate", None)
+                    loss_keys = list(self.network.get_loss_keys())
+                    loss_val = None
+                    for key in loss_keys:
+                        if key in batch:
+                            loss_val = batch[key]
+                            break
+                    if isinstance(loss_val, mx.array):
+                        loss_val = float(loss_val.item())
+                    steps_per_sec = 1.0 / max(time.time() - batch_start, 1e-8)
+                    print(
+                        f"FastMLX-Train: step: {step}; {loss_keys[0] if loss_keys else 'loss'}: {loss_val}; "
+                        f"model_lr: {lr}; steps/sec: {steps_per_sec:.2f};"
+                    )
             for t in self.traces:
                 if hasattr(t, "on_epoch_end"):
                     t.on_epoch_end(state)
-            print(f"Epoch {epoch+1}: {state['metrics']}")
+            epoch_time = time.time() - epoch_start
+            print(f"FastMLX-Train: step: {step}; epoch: {epoch+1}; epoch_time: {epoch_time:.2f} sec;")
         return state
 
     def test(self) -> MutableMapping[str, object]:


### PR DESCRIPTION
## Summary
- fix CIFAR10 dataset loader by converting labels to Python ints before creating MLX arrays
- add a logging interval option to `Estimator` and print training progress similar to FastEstimator

## Testing
- `pytest -q`
- `pytest tests/test_mnist_data.py::TestMNISTLoadData::test_load_data_converts_numpy_scalars -q`