### PR TITLE
Improve FastMLX training loop and ResNet9

### DIFF
--- a/fastmlx/architecture/resnet9.py
+++ b/fastmlx/architecture/resnet9.py
@@ -52,6 +52,8 @@ class ResNet9(nn.Module):
         x = nn.leaky_relu(self.bn3(self.conv3(x)), negative_slope=0.1)
         x = self.pool(x)
         x = x + self.res3(x)
-        x = x.reshape(x.shape[0], -1)
+        # Global pooling to reduce the spatial dimensions down to 1x1 so that
+        # the final fully connected layer receives 512 features per sample.
+        x = mx.max(x, axis=(1, 2))
         x = nn.softmax(self.fc(x), axis=-1)
         return x

--- a/fastmlx/estimator.py
+++ b/fastmlx/estimator.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from typing import Iterable, List, MutableMapping, Optional
+import math
+import time
 
 import mlx.core as mx
 
@@ -25,13 +27,15 @@ class Estimator:
     def fit(self) -> MutableMapping[str, object]:
         """Train the network with periodic logging similar to FastEstimator."""
 
-        import time
-
         state: MutableMapping[str, object] = {}
         step = 0
+        start_time = time.time()
         print(
             f"FastMLX-Start: step: 1; logging_interval: {self.log_interval}; num_device: 1;"
         )
+        for t in self.traces:
+            if hasattr(t, "on_start"):
+                t.on_start(state)
         for epoch in range(self.epochs):
             epoch_start = time.time()
             state = {"mode": "train", "epoch": epoch, "metrics": {}}
@@ -66,6 +70,53 @@ class Estimator:
                     t.on_epoch_end(state)
             epoch_time = time.time() - epoch_start
             print(f"FastMLX-Train: step: {step}; epoch: {epoch+1}; epoch_time: {epoch_time:.2f} sec;")
+
+            # evaluation phase
+            if self.pipeline.eval_data is not None:
+                eval_state: MutableMapping[str, object] = {"mode": "eval", "epoch": epoch, "metrics": {}}
+                for t in self.traces:
+                    if hasattr(t, "on_epoch_begin"):
+                        t.on_epoch_begin(eval_state)
+                eval_dataset = self.pipeline.eval_data
+                num_batches = math.ceil(len(eval_dataset) / self.pipeline.batch_size)
+                eval_step = 0
+                total_loss = 0.0
+                loss_count = 0
+                for batch in self.pipeline.get_loader("eval"):
+                    eval_step += 1
+                    batch_start = time.time()
+                    eval_state["batch"] = batch
+                    self.network.run(batch, eval_state)
+                    for t in self.traces:
+                        if hasattr(t, "on_batch_end"):
+                            t.on_batch_end(batch, eval_state)
+                    loss_val = batch.get("ce")
+                    if isinstance(loss_val, mx.array):
+                        loss_val = float(loss_val.item())
+                    if loss_val is not None:
+                        total_loss += float(loss_val)
+                        loss_count += 1
+                    if eval_step == 1 or eval_step % self.log_interval == 0 or eval_step == num_batches:
+                        steps_per_sec = 1.0 / max(time.time() - batch_start, 1e-8)
+                        print(f"Eval Progress: {eval_step}/{num_batches}; steps/sec: {steps_per_sec:.2f};")
+                for t in self.traces:
+                    if hasattr(t, "on_epoch_end"):
+                        t.on_epoch_end(eval_state)
+                if loss_count:
+                    eval_state["metrics"]["ce"] = total_loss / loss_count
+                acc = eval_state["metrics"].get("accuracy")
+                ce_val = eval_state["metrics"].get("ce")
+                print(
+                    f"FastMLX-Eval: step: {step}; epoch: {epoch+1}; accuracy: {acc}; ce: {ce_val};"
+                )
+        for t in self.traces:
+            if hasattr(t, "on_finish"):
+                t.on_finish(state)
+        total_time = time.time() - start_time
+        lr = getattr(self.network.ops[0].model.optimizer, "learning_rate", None)
+        print(
+            f"FastMLX-Finish: step: {step}; model_lr: {lr}; total_time: {total_time:.2f} sec;"
+        )
         return state
 
     def test(self) -> MutableMapping[str, object]:

--- a/fastmlx/network.py
+++ b/fastmlx/network.py
@@ -31,6 +31,6 @@ class Network:
         for op in self.ops:
             if isinstance(op, Op) and op.outputs:
                 for k in op.outputs:
-                    if "loss" in k:
+                    if "loss" in k or k in {"ce"}:
                         keys.add(k)
         return keys

--- a/fastmlx/op/tensorop/model.py
+++ b/fastmlx/op/tensorop/model.py
@@ -33,6 +33,9 @@ class UpdateOp(Op):
         if x is None or y is None:
             return None
 
+        if state.get("mode") != "train":
+            return None
+
         if not isinstance(x, mx.array):
             x = mx.array(x)
         if not isinstance(y, mx.array):

--- a/fastmlx/trace/__init__.py
+++ b/fastmlx/trace/__init__.py
@@ -1,7 +1,8 @@
 """Tracing utilities."""
 
-from .metric import Accuracy
+from .base import Trace
+from .metric import Accuracy, LossMonitor
 from .io import BestModelSaver
 from .adapt import LRScheduler
 
-__all__ = ["Accuracy", "BestModelSaver", "LRScheduler"]
+__all__ = ["Trace", "Accuracy", "LossMonitor", "BestModelSaver", "LRScheduler"]

--- a/fastmlx/trace/adapt.py
+++ b/fastmlx/trace/adapt.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import Callable, MutableMapping
 
+from .base import Trace
 
-class LRScheduler:
+
+class LRScheduler(Trace):
     def __init__(self, model, lr_fn: Callable[[int], float]):
         self.model = model
         self.lr_fn = lr_fn

--- a/fastmlx/trace/base.py
+++ b/fastmlx/trace/base.py
@@ -1,0 +1,20 @@
+class Trace:
+    """Minimal Trace base class following FastEstimator semantics."""
+
+    def on_start(self, state):
+        pass
+
+    def on_epoch_begin(self, state):
+        pass
+
+    def on_batch_begin(self, batch, state):
+        pass
+
+    def on_batch_end(self, batch, state):
+        pass
+
+    def on_epoch_end(self, state):
+        pass
+
+    def on_finish(self, state):
+        pass

--- a/fastmlx/trace/io.py
+++ b/fastmlx/trace/io.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import os
 from typing import MutableMapping, Optional
 
+from .base import Trace
+
 import mlx.core as mx
 
 
-class BestModelSaver:
+class BestModelSaver(Trace):
     def __init__(self, model, save_dir: str, metric: str = "accuracy", save_best_mode: str = "max") -> None:
         self.model = model
         self.save_dir = save_dir
@@ -29,3 +31,4 @@ class BestModelSaver:
             # Utilize MLX's built-in model saving utility to properly handle
             # nested parameter structures.
             self.model.save_weights(path)
+            print(f"FastMLX-BestModelSaver: Saved model to {path}")

--- a/fastmlx/trace/metric.py
+++ b/fastmlx/trace/metric.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import MutableMapping
 
+from .base import Trace
+
 import mlx.core as mx
 
 
-class Accuracy:
+class Accuracy(Trace):
     def __init__(self, true_key: str = "y", pred_key: str = "y_pred") -> None:
         self.true_key = true_key
         self.pred_key = pred_key
@@ -31,3 +33,29 @@ class Accuracy:
 
     def on_epoch_end(self, state: MutableMapping[str, object]) -> None:
         state['metrics']["accuracy"] = self.correct / max(1, self.total)
+
+
+class LossMonitor(Trace):
+    """Track the mean of a given loss value over an epoch."""
+
+    def __init__(self, loss_key: str = "ce") -> None:
+        self.loss_key = loss_key
+        self.total: float = 0.0
+        self.count: int = 0
+
+    def on_epoch_begin(self, state: MutableMapping[str, object]) -> None:
+        self.total = 0.0
+        self.count = 0
+
+    def on_batch_end(self, batch: MutableMapping[str, object], state: MutableMapping[str, object]) -> None:
+        loss = batch.get(self.loss_key)
+        if loss is None:
+            return
+        if isinstance(loss, mx.array):
+            loss = float(loss.item())
+        self.total += float(loss)
+        self.count += 1
+
+    def on_epoch_end(self, state: MutableMapping[str, object]) -> None:
+        if self.count:
+            state['metrics'][self.loss_key] = self.total / self.count


### PR DESCRIPTION
## Summary
- add global pooling to ResNet9 to fix linear layer shape mismatch
- introduce Trace base class and LossMonitor metric
- update tracing utilities to use new base class
- print message when best model is saved
- refine Estimator to run eval each epoch and emit FastEstimator-style logs
- skip gradient updates during eval
- detect cross entropy losses for logging

## Testing
- `pytest -q`