### PR TITLE
Port CIFAR-10 apphub

### DIFF
--- a/fastmlx/op/coarse_dropout.py
+++ b/fastmlx/op/coarse_dropout.py
@@ -20,8 +20,6 @@ class CoarseDropout(Op):
         self.fill_value = fill_value
 
     def forward(self, data: mx.array, state: MutableMapping[str, Any]) -> mx.array:
-        if not isinstance(data, mx.array):
-            data = mx.array(data)
         x = np.array(data)
         if x.ndim == 4:
             batch, h, w, c = x.shape

--- a/fastmlx/op/cross_entropy.py
+++ b/fastmlx/op/cross_entropy.py
@@ -16,9 +16,5 @@ class CrossEntropy(Op):
 
     def forward(self, data: Sequence[mx.array], state: MutableMapping[str, Any]) -> mx.array:
         y_pred, y_true = data
-        if not isinstance(y_pred, mx.array):
-            y_pred = mx.array(y_pred)
-        if not isinstance(y_true, mx.array):
-            y_true = mx.array(y_true)
         loss = nn.losses.cross_entropy(y_pred, y_true)
         return mx.mean(loss)

--- a/fastmlx/op/expand_dims.py
+++ b/fastmlx/op/expand_dims.py
@@ -15,6 +15,4 @@ class ExpandDims(Op):
         self.axis = axis
 
     def forward(self, data: mx.array, state: MutableMapping[str, Any]) -> mx.array:
-        if not isinstance(data, mx.array):
-            data = mx.array(data)
         return mx.expand_dims(data, axis=self.axis)

--- a/fastmlx/op/horizontal_flip.py
+++ b/fastmlx/op/horizontal_flip.py
@@ -16,8 +16,6 @@ class HorizontalFlip(Op):
         self.prob = prob
 
     def forward(self, data: mx.array, state: MutableMapping[str, Any]) -> mx.array:
-        if not isinstance(data, mx.array):
-            data = mx.array(data)
         x = np.array(data)
         if np.random.rand() < self.prob:
             if x.ndim == 4:

--- a/fastmlx/op/minmax.py
+++ b/fastmlx/op/minmax.py
@@ -14,6 +14,4 @@ class Minmax(Op):
         super().__init__(inputs, outputs)
 
     def forward(self, data: mx.array, state: MutableMapping[str, Any]) -> mx.array:
-        if not isinstance(data, mx.array):
-            data = mx.array(data)
         return data.astype(mx.float32) / 255.0

--- a/fastmlx/op/model_op.py
+++ b/fastmlx/op/model_op.py
@@ -18,6 +18,4 @@ class ModelOp(Op):
         self.model: nn.Module = model
 
     def forward(self, data: Any, state: MutableMapping[str, Any]) -> Array:
-        if not isinstance(data, mx.array):
-            data = mx.array(data)
         return self.model(data)

--- a/fastmlx/op/normalize.py
+++ b/fastmlx/op/normalize.py
@@ -20,7 +20,5 @@ class Normalize(Op):
         self.max_pixel_value = max_pixel_value
 
     def forward(self, data: mx.array, state: MutableMapping[str, Any]) -> mx.array:
-        if not isinstance(data, mx.array):
-            data = mx.array(data)
         x = data.astype(mx.float32) / self.max_pixel_value
         return (x - self.mean) / self.std

--- a/fastmlx/op/onehot.py
+++ b/fastmlx/op/onehot.py
@@ -18,8 +18,6 @@ class Onehot(Op):
         self.label_smoothing = label_smoothing
 
     def forward(self, data: mx.array, state: MutableMapping[str, Any]) -> mx.array:
-        if not isinstance(data, mx.array):
-            data = mx.array(data)
         y = np.array(data).astype(int)
         oh = np.eye(self.num_classes, dtype=np.float32)[y]
         if self.label_smoothing:

--- a/fastmlx/op/pad_if_needed.py
+++ b/fastmlx/op/pad_if_needed.py
@@ -19,8 +19,6 @@ class PadIfNeeded(Op):
         self.value = value
 
     def forward(self, data: mx.array, state: MutableMapping[str, Any]) -> mx.array:
-        if not isinstance(data, mx.array):
-            data = mx.array(data)
         x = np.array(data)
         if x.ndim == 4:
             batch, h, w, c = x.shape

--- a/fastmlx/op/random_crop.py
+++ b/fastmlx/op/random_crop.py
@@ -17,8 +17,6 @@ class RandomCrop(Op):
         self.width = width
 
     def forward(self, data: mx.array, state: MutableMapping[str, Any]) -> mx.array:
-        if not isinstance(data, mx.array):
-            data = mx.array(data)
         x = np.array(data)
         if x.ndim == 4:
             batch, h, w, c = x.shape

--- a/fastmlx/op/update_op.py
+++ b/fastmlx/op/update_op.py
@@ -25,11 +25,6 @@ class UpdateOp(Op):
             return None
         if state.get("mode") != "train":
             return None
-        if not isinstance(x, mx.array):
-            x = mx.array(x)
-        if not isinstance(y, mx.array):
-            y = mx.array(y)
-
         def loss_fn(x_data, y_data):
             logits = self.model(x_data)
             loss = nn.losses.cross_entropy(logits, y_data)

--- a/fastmlx/trace/metric.py
+++ b/fastmlx/trace/metric.py
@@ -23,13 +23,12 @@ class Accuracy(Trace):
     def on_batch_end(self, batch: MutableMapping[str, object], state: MutableMapping[str, object]) -> None:
         y = batch[self.true_key]
         y_pred = batch[self.pred_key]
-        if not isinstance(y_pred, mx.array):
-            y_pred = mx.array(y_pred)
-        if not isinstance(y, mx.array):
-            y = mx.array(y)
+        # ``y`` may be provided either as integer labels or one-hot vectors.
+        # Convert to integer labels to simplify the equality check.
         pred = mx.argmax(y_pred, axis=-1)
-        self.correct += int(mx.sum(pred == y).item())
-        self.total += y.shape[0]
+        true = mx.argmax(y, axis=-1) if y.ndim > 1 else y
+        self.correct += int(mx.sum(pred == true).item())
+        self.total += true.shape[0]
 
     def on_epoch_end(self, state: MutableMapping[str, object]) -> None:
         state['metrics']["accuracy"] = self.correct / max(1, self.total)


### PR DESCRIPTION
## Summary
- remove type casts from ops
- relax accuracy trace to handle one-hot or integer labels
- dataset ensures MLX arrays for CIFAR-10

## Testing
- `pytest -q`