### PR TITLE
Fix CIFAR-10 training

### DIFF
--- a/fastmlx/apphub/cifar10.py
+++ b/fastmlx/apphub/cifar10.py
@@ -29,7 +29,12 @@ def lr_schedule(step):
         lr = (2352 - step) / 1862 * 0.4
     return lr * 0.1
 
-def get_estimator(epochs: int = 24, batch_size: int = 512, save_dir: str = tempfile.mkdtemp()) -> fe.Estimator:
+def get_estimator(
+    epochs: int = 24,
+    batch_size: int = 512,
+    save_dir: str = tempfile.mkdtemp(),
+    num_process: int | None = None,
+) -> fe.Estimator:
     train_data, eval_data = cifar10.load_data()
     pipeline = fe.Pipeline(
         train_data=train_data,
@@ -43,6 +48,7 @@ def get_estimator(epochs: int = 24, batch_size: int = 512, save_dir: str = tempf
             CoarseDropout(inputs="x", outputs="x", max_holes=1),
             Onehot(inputs="y", outputs="y", num_classes=10, label_smoothing=0.2),
         ],
+        num_process=num_process,
     )
     model = fe.build(model_fn=lambda: ResNet9(input_shape=(3, 32, 32)), optimizer_fn="adam")
     network = fe.Network([

--- a/fastmlx/apphub/mnist.py
+++ b/fastmlx/apphub/mnist.py
@@ -13,13 +13,19 @@ from fastmlx.trace.io import BestModelSaver
 from fastmlx.trace.adapt import LRScheduler
 
 
-def get_estimator(epochs: int = 2, batch_size: int = 32, save_dir: str = tempfile.mkdtemp()) -> fe.Estimator:
+def get_estimator(
+    epochs: int = 2,
+    batch_size: int = 32,
+    save_dir: str = tempfile.mkdtemp(),
+    num_process: int | None = None,
+) -> fe.Estimator:
     train_data, eval_data = mnist.load_data()
     pipeline = fe.Pipeline(
         train_data=train_data,
         eval_data=eval_data,
         batch_size=batch_size,
         ops=[Minmax(inputs="x", outputs="x")],
+        num_process=num_process,
     )
     model = fe.build(model_fn=lambda: LeNet(input_shape=(1,28,28)), optimizer_fn="adam")
     network = fe.Network([

--- a/fastmlx/architecture/lenet.py
+++ b/fastmlx/architecture/lenet.py
@@ -29,5 +29,5 @@ class LeNet(nn.Module):
         x = nn.relu(self.conv3(x))
         x = x.reshape(x.shape[0], -1)
         x = nn.relu(self.fc1(x))
-        x = nn.softmax(self.fc2(x), axis=-1)
+        x = self.fc2(x)
         return x

--- a/fastmlx/architecture/resnet9.py
+++ b/fastmlx/architecture/resnet9.py
@@ -55,5 +55,5 @@ class ResNet9(nn.Module):
         # Global pooling to reduce the spatial dimensions down to 1x1 so that
         # the final fully connected layer receives 512 features per sample.
         x = mx.max(x, axis=(1, 2))
-        x = nn.softmax(self.fc(x), axis=-1)
+        x = self.fc(x)
         return x

--- a/tests/test_mnist_estimator.py
+++ b/tests/test_mnist_estimator.py
@@ -17,7 +17,7 @@ class TestMNISTEstimator(unittest.TestCase):
             ]
 
         with patch("fastmlx.dataset.data.mnist.mlx_mnist.load_mnist", side_effect=fake_load_mnist):
-            est = mnist_app.get_estimator(epochs=1, batch_size=2)
+            est = mnist_app.get_estimator(epochs=1, batch_size=2, num_process=0)
             loader = est.pipeline.get_loader("train")
             batch = next(iter(loader))
             state = {"mode": "train"}

--- a/tests/test_mnist_training.py
+++ b/tests/test_mnist_training.py
@@ -24,7 +24,7 @@ class TestMNISTTraining(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("fastmlx.dataset.data.mnist.mlx_mnist.load_mnist", side_effect=fake_load_mnist):
-                est = mnist_app.get_estimator(epochs=1, batch_size=2, save_dir=tmpdir)
+                est = mnist_app.get_estimator(epochs=1, batch_size=2, save_dir=tmpdir, num_process=0)
                 # Simplify accuracy computation and bypass network execution to
                 # avoid triggering heavy JIT compilation during tests.
                 def simple_acc(self, batch, state):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -18,6 +18,7 @@ class TestPipeline(unittest.TestCase):
             train_data=data,
             batch_size=2,
             ops=[Minmax("x", "x")],
+            num_process=0,
         )
         loader = pipe.get_loader("train")
         batch = next(iter(loader))


### PR DESCRIPTION
## Summary
- default pipeline to use all CPUs via thread pool
- remove softmax from LeNet and ResNet9 outputs
- allow apphub estimators to pass pipeline worker count
- update unit tests for new defaults

## Testing
- `pytest -q`