### PR TITLE
Fix MNIST dataloader issue

### DIFF
--- a/AGENT_SCRATCHPAD.md
+++ b/AGENT_SCRATCHPAD.md
@@ -5,3 +5,9 @@ Data Loader Notes:
   parallelism.
 Pipeline Ops Notes:
 * Pipeline ops accept a state argument but the pipeline passes an empty dict since preprocessing typically has no global state.
+
+Additional Notes:
+* When the dataset already consists of MLX arrays (for example ``MLXDataset``),
+  batching by direct array slicing avoids creating a ``mlx.data.Buffer``. This
+  reduces memory usage and sidesteps some ``mlx.data`` event errors encountered
+  with very large datasets.

--- a/fastmlx/pipeline.py
+++ b/fastmlx/pipeline.py
@@ -46,31 +46,60 @@ class Pipeline:
         self.num_process: int = mp.cpu_count() if num_process is None else num_process
 
     def _loader(self, dataset: Iterable) -> Iterator[MutableMapping[str, object]]:
-        """Create an iterator over processed batches using ``mlx.data``."""
+        """Create an iterator over processed batches."""
 
         if isinstance(dataset, dx.Buffer):
             buffer = dataset
+
+            def transform(sample: MutableMapping[str, object]) -> MutableMapping[str, object]:
+                mx_sample = {k: mx.array(v) for k, v in sample.items()}
+                return _process_sample(mx_sample, self.ops, {})
+
+            stream = buffer.sample_transform(transform)
+            stream = stream.batch(self.batch_size)
+            if self.num_process and self.num_process > 0:
+                stream = stream.ordered_prefetch(self.batch_size * 2, self.num_process)
+
+            for batch in stream:
+                # ``stream`` yields numpy arrays, convert to MLX arrays
+                yield {k: mx.array(v) for k, v in batch.items()}
+
         elif hasattr(dataset, "data") and hasattr(dataset, "__len__"):
-            samples = [
-                {k: v[i] for k, v in dataset.data.items()}
-                for i in range(len(dataset))
-            ]
-            buffer = dx.buffer_from_vector(samples)
+            arrays = {k: mx.array(v) for k, v in dataset.data.items()}
+            size = len(dataset)
+
+            def apply_ops(batch: MutableMapping[str, mx.array]) -> MutableMapping[str, mx.array]:
+                state: MutableMapping[str, object] = {}
+                for op in self.ops:
+                    inp = batch[op.inputs[0]] if len(op.inputs) == 1 else [batch[k] for k in op.inputs]
+                    out = op.forward(inp, state)
+                    if op.outputs:
+                        if len(op.outputs) == 1:
+                            batch[op.outputs[0]] = out
+                        else:
+                            for k_out, v_out in zip(op.outputs, out):
+                                batch[k_out] = v_out
+                return batch
+
+            for start in range(0, size, self.batch_size):
+                batch = {k: v[start:start + self.batch_size] for k, v in arrays.items()}
+                batch = apply_ops(batch)
+                yield batch
+
         else:
             buffer = dx.buffer_from_vector(list(dataset))
 
-        def transform(sample: MutableMapping[str, object]) -> MutableMapping[str, object]:
-            mx_sample = {k: mx.array(v) for k, v in sample.items()}
-            return _process_sample(mx_sample, self.ops, {})
+            def transform(sample: MutableMapping[str, object]) -> MutableMapping[str, object]:
+                mx_sample = {k: mx.array(v) for k, v in sample.items()}
+                return _process_sample(mx_sample, self.ops, {})
 
-        stream = buffer.sample_transform(transform)
-        stream = stream.batch(self.batch_size)
-        if self.num_process and self.num_process > 0:
-            stream = stream.ordered_prefetch(self.batch_size * 2, self.num_process)
+            stream = buffer.sample_transform(transform)
+            stream = stream.batch(self.batch_size)
+            if self.num_process and self.num_process > 0:
+                stream = stream.ordered_prefetch(self.batch_size * 2, self.num_process)
 
-        for batch in stream:
-            # ``stream`` yields numpy arrays, convert to MLX arrays
-            yield {k: mx.array(v) for k, v in batch.items()}
+            for batch in stream:
+                yield {k: mx.array(v) for k, v in batch.items()}
 
     def get_loader(self, mode: str = "train") -> Iterator[MutableMapping[str, object]]:
         dataset = self.train_data if mode == "train" else self.eval_data


### PR DESCRIPTION
## Summary
- avoid using `mlx.data.Buffer` for in-memory datasets
- slice MLX arrays directly for batching to reduce memory usage
- document new info in AGENT_SCRATCHPAD

## Testing
- `pytest -q`